### PR TITLE
Add new ComponentScan paths

### DIFF
--- a/back-end/src/main/java/rennesgo/RennesGo.java
+++ b/back-end/src/main/java/rennesgo/RennesGo.java
@@ -5,6 +5,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+@ComponentScan({ "rennesgo.auth","rennesgo.controller", "rennesgo.data"})
 public class RennesGo {
 	public static void main(final String[] args) {
 		final SpringApplication app = new SpringApplication(RennesGo.class);


### PR DESCRIPTION
Add new ComponentScan to fixing jar link issue with spring boot maven plugin.

Without this addition, jar generated can't run properly :
`.UnsatisfiedDependencyException: Error creating bean with name 'userController' defined in URL`